### PR TITLE
Allow normalized bounding boxes to be tracked

### DIFF
--- a/motrackers/tracker.py
+++ b/motrackers/tracker.py
@@ -102,7 +102,7 @@ class Tracker:
             detections (list[Tuple]): Data for detections as list of tuples containing `(bbox, class_id, detection_score)`.
         """
 
-        new_bboxes = np.array(bboxes, dtype='int')
+        new_bboxes = np.array(bboxes, dtype='float')
         new_class_ids = np.array(class_ids, dtype='int')
         new_detection_scores = np.array(detection_scores)
 


### PR DESCRIPTION
A simple fix that changes the numpy array wrapping to `float` to allow normalized bounding boxes to be tracked (instead of only pixel based).