### PR TITLE
Fixes bug if python lists are used to update the centroid tracker

### DIFF
--- a/motrackers/tracker.py
+++ b/motrackers/tracker.py
@@ -144,7 +144,7 @@ class Tracker:
 
         if len(track_ids):
             track_centroids = np.array([self.tracks[tid].centroid for tid in track_ids])
-            detection_centroids = get_centroid(bboxes)
+            detection_centroids = get_centroid(np.asarray(bboxes))
 
             centroid_distances = distance.cdist(track_centroids, detection_centroids)
 


### PR DESCRIPTION
If python lists are used to update the centroid tracker it tries to get the centroid and uses the numpy `shape` attribute wich is not accessible on python lists. This fix converts the bounding boxes into a numpy array first to allow lists & numpy arrays (as stated in the documentation).