### PR TITLE
PyPI 2nd Attempt. Closes #43

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -39,6 +39,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
+      # https://github.com/actions/first-interaction/issues/10#issuecomment-1475121828
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,16 +18,12 @@ jobs:
 
     steps:
       - name: Checkout source
-      - uses: actions/checkout@v3
+        uses: actions/checkout@v3
 
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
           python-version: '3.x'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
 
       - name: Build source and wheel distributions
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.run_id }}
-          release_name: ${{ github.run_id }}
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,7 +34,7 @@ jobs:
           twine check --strict dist/*
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ github.run_id }}
+          release_name: ${{ github.run_id }}
           draft: false
           prerelease: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motrackers_test"
-version = "0.0.2"
+version = "0.0.3"
 description = "Multi-object trackers in Python"
 authors = [
     {name = "Aditya M. Deshpande", email = "adityadeshpande2010@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "motrackers"
-version = "v0.0.1"
+version = "0.0.1"
 description = "Multi-object trackers in Python"
 authors = [
-{name = "Aditya M. Deshpande", email = "adityadeshpande2010@gmail.com"},
+    {name = "Aditya M. Deshpande", email = "adityadeshpande2010@gmail.com"}
 ]
 license = {file = "LICENSE.txt"}
-readme = "[README.md](http://readme.md/)"
+readme = "README.md"
 requires-python = ">3.6"
 
 keywords = ["tracking", "object", "multi-object", "python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "motrackers_test"
-version = "0.0.3"
+name = "motrackers"
+version = "0.0.1"
 description = "Multi-object trackers in Python"
 authors = [
     {name = "Aditya M. Deshpande", email = "adityadeshpande2010@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "motrackers_test"
-version = "0.0.1"
+version = "0.0.2"
 description = "Multi-object trackers in Python"
 authors = [
     {name = "Aditya M. Deshpande", email = "adityadeshpande2010@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "motrackers"
+name = "motrackers_test"
 version = "0.0.1"
 description = "Multi-object trackers in Python"
 authors = [


### PR DESCRIPTION
Hello @adipandas 

Okay, I think we finally got it right. Just had to fix minor issues with ``pyproject.toml`` and the GA workflow. I was able to publish a test version of the package here: [motrackers-test](https://pypi.org/project/motrackers-test/). I will delete the package after you get ``motrackers`` published.

Now the GA action should pass, only failing now because I am running in a fork. Here is the [GA action report](https://github.com/edavalosanaya/multi-object-tracker/actions/runs/4941828919/jobs/8834825335), it successfully publishes to PyPI but fails later because its a fork (according to Google and ChatGPT).

Things you need to do:
1. Delete local tag ``v0.0.1`` with the following command
```
$ git tag -d v0.0.1
```
2. Delete remote tag ``v0.0.1``. You can do so by selecting the tag from the ``Tags/Releases`` right-side panel on GitHub and deleting it from the ``...`` menu button.
3. Triple-check that you have a ``PYPI_API_TOKEN`` in your GitHub repo secrets
4. Try again to publish (hopefully this time is much smoother), with the following command:
```
git tag v0.0.1
git push origin --tags
```
5. Wait and see if the GitHub actions are successful

Again, thanks for trying this out! Hopefully, soon we can get the package up in PyPI and make uploads a breeze in the future!